### PR TITLE
Sync .gitignore and CI/CD workflow with gautada templates

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -1,0 +1,58 @@
+---
+name: "Continuous Integration: Build and Publish Multi-Architecture Container Images"
+# This is the generic reusable template for building containers
+
+'on':
+  workflow_dispatch: {}
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    uses: gautada/cicd/.github/workflows/ci-linter.yaml@main
+  build-arm64:
+    needs: check
+    uses: gautada/cicd/.github/workflows/ci-podman-build.yaml@main
+    with:
+      architecture: "arm64"
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  build-amd64:
+    needs: check
+    uses: gautada/cicd/.github/workflows/ci-podman-build.yaml@main
+    with:
+      architecture: "amd64"
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  publish:
+    needs: [build-arm64, build-amd64]
+    uses: gautada/cicd/.github/workflows/ci-podman-publish.yaml@main
+    with:
+      architectures: '["arm64", "amd64"]'
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  clean:
+    needs: [publish]
+    uses: gautada/cicd/.github/workflows/ci-registry-clean.yaml@main
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  test:
+    needs: [clean]
+    uses: gautada/cicd/.github/workflows/ci-container-test.yaml@main
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}
+  release:
+    needs: [test]
+    uses: gautada/cicd/.github/workflows/cd-tag-latest.yaml@main
+    secrets:
+      REGISTRY_USERNAME: ${{ secrets.DOCKERIO_REGISTRY }}
+      REGISTRY_TOKEN: ${{ secrets.DOCKERIO_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# This template file is stored at
+# [GitHub Gist](https://gist.github.com/gautada/3a0a4a76d3c7e4539e71fc02c7f599ad)
+
+# XCode - Project files 
+*.xcodeproj/
+
+# Desktop Services Store - Custom view preferences
+.DS_Store
+
+# **Volume Folders** are used in development to set runtime data, usuaully 
+# this is private data and should almost **NEVER** be loaded into version
+# control
+**-volume/
+
+# **Manifest Folder** is the k8s yaml files that deploy the container, usually
+# this folder is sourced from a private repository and should not be public.
+manifest/
+
+# `.dockerignore` file allows you to specify a list of files or directories 
+# that Docker is to ignore during the build process. To create jusr
+# symlink to this files `ln -s .gitignore .dockerignore`
+.dockerignore
+
+.env
+.flake8
+.hadolint.yaml
+.htmlhintrc
+.jscpd.json
+.markdownlint.yaml
+.pre-commit-config.yaml
+.sqlfluff
+.yamllint.yaml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # silverbullet
-A silverbullet  container
+
+A silverbullet container


### PR DESCRIPTION
## Summary
- Synchronized `.gitignore` with the canonical template from `gautada/cicd`.
- Detected the correct CI/CD workflow template (`cicd-container`) via repo topics and installed `.github/workflows/cicd.yaml`.
- Cleaned up local `pre-commit` config files to ensure they are managed via the sync process.
- Verified repository health with the standard pre-commit suite.

## Testing
- Pre-commit checks passed locally.
- Verified `cicd-container` topic exists on the repository.