### PR TITLE
Refine version reporting

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+# ShellCheck configuration
+shell=sh
+disable=SC3040,SC3020,SC3010,SC3010

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,3 +1,0 @@
-# ShellCheck configuration
-shell=sh
-disable=SC3040,SC3020,SC3010,SC3010

--- a/scripts/container-version.sh
+++ b/scripts/container-version.sh
@@ -3,8 +3,10 @@
 # │ VERSION - SILVERBULLET VERSION REPORT                                     │
 # ╰――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――╯
 # This script returns the SilverBullet server version packaged in the container.
+# It parses the verbose output to extract only the major.minor.patch version.
 
-VERSION=$(/usr/local/bin/silverbullet --version 2>&1 | awk '{print $NF}' | tr -d '[:space:]')
+# Example output: Starting SilverBullet version 2.5.2-0-gad45eeb-2026-03-06T12-20-46Z
+VERSION=$(/usr/local/bin/silverbullet --version 2>&1 | awk '/version/ {print $NF}' | cut -d'-' -f1)
 
 if [ -z "$VERSION" ]; then
     printf "unknown\n"


### PR DESCRIPTION
References #8. Updates `scripts/container-version.sh` to parse verbose SilverBullet output and return only the clean `major.minor.patch` version string.